### PR TITLE
Added support for API Version 5 (Home Center 3)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,29 +1,33 @@
+## 0.1.8
+
+- Added support for API version 5 (Home Center 3)
+
 ## 0.1.5
 
-  - renamed files and module to fiblary3
+- renamed files and module to fiblary3
 
 ## 0.1.4
 
-  - works with python3.6
+- works with python3.6
 
 ## 0.1.3
 
-  - fixed issue #3  - Get method without parameters for info, login and weather managers
+- fixed issue #3 - Get method without parameters for info, login and weather managers
 
 ## 0.1.2
 
-  - Simplified the installation.
+- Simplified the installation.
 
 ## 0.1.1
 
 Bugfixes:
 
-  - None
+- None
 
 Features:
 
-  - Event manager added to the client class with example code
+- Event manager added to the client class with example code
 
 ## 0.1.0
 
-  - Initial release
+- Initial release

--- a/fiblary3/__init__.py
+++ b/fiblary3/__init__.py
@@ -18,4 +18,4 @@ API implementation for Home Center 2
 
 """
 
-__version__ = '0.1.7'
+__version__ = '0.1.8'

--- a/fiblary3/client/v5/__init__.py
+++ b/fiblary3/client/v5/__init__.py
@@ -1,3 +1,4 @@
+#  Copyright 2020 Daniel Pervan
 #  Copyright 2014 Klaudiusz Staniek
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,21 +14,9 @@
 #   limitations under the License.
 
 """
-This is a fiblary package providing python API implementation to Home Center
+ fiblary.v5
+ ~~~~~~~~~~~~~~~~~
+
+ Home Center v5 API Module
 
 """
-
-
-from fiblary3.common import utils
-
-
-def Client(version, *args, **kwargs):
-    """This is a client wrapper handling API versioning
-
-    :param version: A version string of the API (i.e. 'v3')
-    :returns: A Home Center Client class
-    """
-
-    module = utils.import_versioned_module('client', version, 'client')
-    client_class = getattr(module, 'Client')
-    return client_class(*args, **kwargs)

--- a/fiblary3/client/v5/base.py
+++ b/fiblary3/client/v5/base.py
@@ -1,0 +1,228 @@
+#  Copyright 2020 Daniel Pervan
+#  Copyright 2014 Klaudiusz Staniek
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""
+ fiblary.v5.base
+ ~~~~~~~~~~~~~~~~~
+
+ Home Center Controller Base Class Implementation
+
+"""
+
+import fiblary3.external.jsonpath as jsonpath
+
+from itertools import filterfalse
+import logging
+import six
+
+from fiblary3.common import exceptions
+from fiblary3.common.utils import quote_if_string
+
+
+_logger = logging.getLogger(__name__)
+
+
+def _check_items(obj, searches):
+    def _check_properties(attr, value):
+        properties = getattr(obj, 'properties', None)
+        if properties:
+            return properties.get(attr) == value
+        return False
+    found = all(((getattr(obj, attr, None) == value) or
+                 _check_properties(attr, value)) for (attr, value) in searches)
+
+    return found
+
+
+class MinimalController(object):
+    """Minimal controller class used as a base class for more
+    specific controllers.
+
+    It implements simple get method for read only resources.
+    """
+
+    RESOURCE = ''
+    API_PARAMS = ()
+    """API PARAMS can be directly passed to the RESTApi
+    This speed up the list operation
+    """
+
+    def __init__(self, http_client, model):
+        self.http_client = http_client
+        self.model = model
+
+    def _get(self, **kwargs):
+        id = kwargs.pop('id', None)
+        url = '{}/{}'.format(self.RESOURCE,
+                             id) if id is not None else self.RESOURCE
+        try:
+            item = self.http_client.get(url, params=kwargs).json()
+        except exceptions.ConnectionError:
+            return None
+        except exceptions.HTTPNotFound:
+            return None
+
+        return item
+
+    def get(self):
+        """Returns :class:`models.Model` object representing. This is
+        applicable for single instance requests i.e. login, info, weather
+
+        :returns: :class:`models.Model` object
+        """
+        item = self._get()
+        return self.model(item)
+
+
+class ReadOnlyController(MinimalController):
+    """Read only controller class used for controllers using get and list
+    methods only
+    """
+    JSON_CONDITION_BASE = "(@.{0}=={1})"
+
+    def get(self, item_id):
+        """Returns :class:`models.Model` object representing an item
+        identified by ``item_id``
+
+        :param item_id: This is an id of the requested object. The item_id
+        encoded in GET request as the 'id' parameter
+        :returns: :class:`models.Model` object
+        """
+
+        # item_it must not be None.
+        if item_id is None:
+            _logger.debug("Called 'get' method with none id")
+            return None
+
+        params = {"id": item_id}
+        item = self._get(**params)
+        return self.model(item)
+
+    def list(self, **kwargs):
+        """
+        :param kwargs: This is a dictionary of parameters passed to GET
+        :type kwargs:
+        :return: Returns an iterator
+        :rtype: iterator function
+        """
+        _logger.debug(self.RESOURCE)
+        _logger.debug(type(self))
+        _logger.debug(kwargs)
+
+        # Pop jsonpath if exists and pass the rest of arguments to API
+        # for some API calls home center handles additional parameters
+
+        json_path = kwargs.pop('jsonpath', None)
+
+        # Home center ignores unknown parameters so there is no need to
+        # remove them from REST request.
+        items = self.http_client.get(self.RESOURCE, params=kwargs).json()
+
+        # if there is no explicit defined json_path parameters
+        if json_path is None:
+            for value in self.API_PARAMS:
+                kwargs.pop(value, None)
+
+            condition_expression = ""
+            for k, v in six.iteritems(kwargs):
+                if k.startswith('p_'):  # search for properties
+                    k = "properties." + k[2:]
+                condition_expression += self.JSON_CONDITION_BASE.format(
+                    k,
+                    quote_if_string(v))
+                condition_expression += " and "
+
+            if condition_expression is not "":
+                # filter the results with json implicit built from
+                # remaining parameters
+
+                json_path = "$[?({})]".format(condition_expression[:-5])
+            _logger.debug("Implicit JSON Path: {}".format(json_path))
+
+        if json_path:
+            _logger.debug("JSON Path: {}".format(json_path))
+            filtered_items = jsonpath.jsonpath(items, json_path)
+            if filtered_items:
+                items = filtered_items
+            else:
+                items = []
+
+        # in case there is only one item
+        items = items if isinstance(items, list) else [items]
+        return filterfalse(lambda i: i is None, map(self.model, items))
+
+    def find(self, **kwargs):
+        """Find single item with attributes matching ``**kwargs``.
+        It also handles nested properties as a keywords.
+        """
+        num_matches = 0
+        found = None
+        items = self.list(**kwargs)
+        for item in items:
+            found = item
+            num_matches += 1
+            if num_matches > 1:  # raise exception not waiting
+                # for the whole list walkthrough
+                raise exceptions.NoUniqueMatch
+
+        if not found:
+            msg = "No matching {0}".format(kwargs)
+            raise exceptions.NotFound(msg)
+
+        return found
+
+
+class CommonController(ReadOnlyController):
+    """Common controller class used as a base class for controllers
+    implementing method changing the data
+    """
+
+    def create(self, **kwargs):
+        item = self.model(kwargs)
+        for (key, value) in list(kwargs.items()):
+            setattr(item, key, value)
+        try:
+            response = self.http_client.post(self.RESOURCE, data=item)
+        except exceptions.ConnectionError:
+            return None
+
+        try:
+            item = response.json()
+        except ValueError:
+            _logger.warning(
+                "Invalid JSON format. Received: '{}'".format(response.text))
+            return None
+
+        return self.model(item)
+
+    def delete(self, item_id):
+        url = '{0}?id={1}'.format(self.RESOURCE, item_id)
+        self.http_client.delete(url)
+        return
+
+    def update(self, data):
+        try:
+            response = self.http_client.put(self.RESOURCE, json=data)
+        except exceptions.ConnectionError:
+            return None
+
+        try:
+            item = response.json()
+        except ValueError:
+            _logger.warning(
+                "Invalid JSON format. Received: '{}'".format(response.text))
+            return None
+
+        return self.model(item)

--- a/fiblary3/client/v5/client.py
+++ b/fiblary3/client/v5/client.py
@@ -1,0 +1,287 @@
+#  Copyright 2020 Daniel Pervan
+#  Copyright 2014 Klaudiusz Staniek
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""
+ fiblary.client
+ ~~~~~~~~~~~~~~
+
+ Home Center Controller Client Implementation
+
+"""
+import logging
+import sys
+import threading
+
+from fiblary3.client.v5 import devices
+from fiblary3.client.v5 import events
+from fiblary3.client.v5 import info
+from fiblary3.client.v5 import login
+from fiblary3.client.v5 import models
+from fiblary3.client.v5 import rooms
+from fiblary3.client.v5 import scenes
+from fiblary3.client.v5 import sections
+from fiblary3.client.v5 import users
+from fiblary3.client.v5 import variables
+from fiblary3.client.v5 import weather
+
+from fiblary3.common.event import EventHook
+from fiblary3.common import exceptions
+from fiblary3.common import restapi
+
+
+_logger = logging.getLogger(__name__)
+
+_schema_ignore = ["HC_user", "VOIP_user", "weather", "iOS_device", ""]
+
+
+class Client(object):
+    """Home Center 3 Client Class.
+    Provides interface to different resources managed by HC3
+    through the specialized controllers
+    """
+
+    def __init__(self, endpoint, username=None, password=None):
+
+        if "/api/" not in endpoint:
+            raise IOError(
+                "Wrong API string. It should be like: " "http://<hc3_ip>/api/"
+            )
+
+        # TODO(klstanie):  Add the HC2 reachability checking
+
+        self.client = restapi.RESTApi(
+            base_url=endpoint, username=username, password=password, debug=False
+        )
+        self.client.set_header("Fibaro Header", "X-Fibaro-Version:2")
+
+        self.modified = {}
+        self.modified_lock = threading.Lock()
+
+        # initialize the managers
+        self.info = info.Controller(self.client, self._get_info_model())
+
+        self.login = login.Controller(self.client, self._get_login_model())
+
+        self.sections = sections.Controller(
+            self.client, self._get_section_model())
+
+        self.rooms = rooms.Controller(self.client, self._get_room_model())
+
+        self.users = users.Controller(self.client, self._get_user_model())
+
+        self.variables = variables.Controller(
+            self.client, self._get_variable_model())
+
+        self.scenes = scenes.Controller(self.client, self._get_scene_model())
+
+        self.devices = devices.Controller(
+            self.client, self._get_device_model())
+
+        self.weather = weather.Controller(
+            self.client, self._get_weather_model())
+
+        self.events = events.Controller(self.client, self._get_event_model())
+
+        self.state_handler = None
+
+    def _get_info_model(self):
+        def model(item):
+            return models.factory(self.info, item)
+
+        return model
+
+    def _get_login_model(self):
+        def model(item):
+            return models.factory(self.login, item)
+
+        return model
+
+    def _get_section_model(self):
+        def model(item):
+            return models.factory(self.sections, item)
+
+        return model
+
+    def _get_room_model(self):
+        def model(item):
+            return models.factory(self.rooms, item)
+
+        return model
+
+    def _get_user_model(self):
+        def model(item):
+            return models.factory(self.users, item)
+
+        return model
+
+    def _get_variable_model(self):
+        def model(item):
+            return models.factory(self.variables, item)
+
+        return model
+
+    def _get_weather_model(self):
+        def model(item):
+            return models.factory(self.weather, item)
+
+        return model
+
+    def _get_event_model(self):
+        def model(item):
+            return models.factory(self.events, item)
+
+        return model
+
+    def _get_scene_model(self):
+        def model(item):
+            return models.factory(self.scenes, item)
+
+        return model
+
+    def _get_device_model(self):
+        def model(item):
+            return models.factory(self.devices, item)
+
+        return model
+
+    def __repr__(self):
+        return "Home Center 3 Client"
+
+    def _on_property_change(self, **kwargs):
+        property_name = kwargs.get("property", None)
+        if not property_name:
+            return
+        try:
+            self.modified[property_name](**kwargs)
+        except Exception:
+            # trick to reduce number of exceptions
+            with self.modified_lock:
+                self.modified[property_name] = EventHook(property_name)
+            _logger.warning(
+                "Missing state handler for: {}".format(property_name))
+
+    def _on_state_change(self, state):
+        timestamp = state.get("timestamp", 0)
+        for change in state.get("changes", []):
+            device_id = change.pop("id")
+            for property_name, value in list(change.items()):
+                data = {
+                    "timestamp": timestamp,
+                    "id": device_id,
+                    "property": property_name,
+                    "value": value,
+                    "client": self,
+                }
+                self._on_property_change(**data)
+
+    # API
+
+    def enable_state_handler(self):
+        self.state_handler = StateHandler(self, self._on_state_change)
+
+    def disable_state_handler(self):
+        self.state_handler.stop()
+
+    def add_event_handler(self, property_name, handler):
+        if property_name not in self.modified:
+            with self.modified_lock:
+                self.modified[property_name] = EventHook(property_name)
+
+        self.modified[property_name] += handler
+
+    def remove_event_handler(self, property_name, handler):
+        try:
+            self.modified[property_name] -= handler
+        except ValueError:
+            raise exceptions.HandlerNotFound(
+                message="Handler for property '{}' not found: {}.".format(
+                    property_name, handler.__name__
+                )
+            )
+
+
+class StateHandler(threading.Thread):
+    def __init__(self, client, callback):
+        super(StateHandler, self).__init__(name=self.__class__.__name__)
+        self.client = client
+        self.api = client.client
+        self.callback = callback
+        self.daemon = True  # stop unconditionally on exit
+
+        self._stop = threading.Event()
+
+        self.start()
+
+    def run(self):
+        """State Handler main loop"""
+
+        _logger.info("Starting the state change handler")
+        last = "0"
+        while not self.stopped():
+
+            timeout = 60
+            sleep_time = 1
+            attempt = 1
+            success = False
+
+            while not success:
+                if self.stopped():
+                    break
+
+                try:
+                    state = self.api.get(
+                        "refreshStates?last={}".format(last), timeout=timeout
+                    )
+                    _logger.debug(state)
+                    try:
+                        state = state.json()
+                    except Exception:
+                        _logger.critical("JSON ERROR: {}".format(state))
+                        raise
+                    last = state["last"]
+                    self.callback(state)
+                    success = True
+                    break
+
+                except Exception:
+                    _logger.warn(
+                        "Connection Error. Attempt number: {}".format(attempt))
+                    e = sys.exc_info()
+                    _logger.exception("Exception: {}".format(str(e)))
+
+                    attempt += 1
+
+                if not success:
+                    if attempt == 10:
+                        sleep_time = 30
+                        _logger.warn(
+                            "Fallback to 30-second connection retry timer.")
+
+                    _logger.warn(
+                        "Waiting for next attempt {} second(s)".format(
+                            sleep_time)
+                    )
+                    self._stop.wait(sleep_time)
+
+        _logger.info("State change handler stopped.")
+
+    def stopped(self):
+        return self._stop.isSet()
+
+    def stop(self):
+        _logger.info("Stopping the state change handler")
+
+        self.api.session.close()  # not effect on pending request
+        self._stop.set()

--- a/fiblary3/client/v5/devices.py
+++ b/fiblary3/client/v5/devices.py
@@ -1,0 +1,61 @@
+#  Copyright 2020 Daniel Pervan
+#  Copyright 2014 Klaudiusz Staniek
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""
+ fiblary.devices
+ ~~~~~~~~~~~~~~
+
+ Home Center Device Manager Implementation
+"""
+
+from fiblary3.client.v5 import base
+from fiblary3.common import exceptions
+
+import logging
+
+
+_logger = logging.getLogger(__name__)
+
+
+class Controller(base.CommonController):
+    RESOURCE = 'devices'
+    API_PARAMS = ('id', 'type', 'roomID')
+
+    def action(self, device_id, action, *args):
+        cmd = 'devices/{}/action/{}'.format(device_id, action)
+        if args:
+            data = '{ "args":'
+            for i, arg in enumerate(args):
+                if (i > 1):
+                    data = '{}, '.format(data)
+                data = '{}"{}"'.format(data, arg)
+        else:
+            data = "{}"
+        resp = self.http_client.post(cmd, data=data)
+        if resp.status_code != 200 and resp.status_code != 202:
+            exceptions.from_response(resp)
+
+    def update(self, data):
+        try:
+            """
+            HC2 does not like those properties to be PUT
+            """
+            data.properties.pop("associationView")
+            data.properties.pop("associationSet")
+
+        except Exception:
+            pass
+
+        return super(Controller, self).update(data)

--- a/fiblary3/client/v5/events.py
+++ b/fiblary3/client/v5/events.py
@@ -1,3 +1,4 @@
+#  Copyright 2020 Daniel Pervan
 #  Copyright 2014 Klaudiusz Staniek
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,21 +14,15 @@
 #   limitations under the License.
 
 """
-This is a fiblary package providing python API implementation to Home Center
+ fiblary.info
+ ~~~~~~~~~~~~~~
 
+ Home Center Info Manager Implementation
 """
 
+from fiblary3.client.v5 import base
 
-from fiblary3.common import utils
 
-
-def Client(version, *args, **kwargs):
-    """This is a client wrapper handling API versioning
-
-    :param version: A version string of the API (i.e. 'v3')
-    :returns: A Home Center Client class
-    """
-
-    module = utils.import_versioned_module('client', version, 'client')
-    client_class = getattr(module, 'Client')
-    return client_class(*args, **kwargs)
+class Controller(base.ReadOnlyController):
+    RESOURCE = 'panels/event'
+    API_PARAMS = ('last', 'from', 'to', 'type', 'deviceID')

--- a/fiblary3/client/v5/info.py
+++ b/fiblary3/client/v5/info.py
@@ -1,3 +1,4 @@
+#  Copyright 2020 Daniel Pervan
 #  Copyright 2014 Klaudiusz Staniek
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,21 +14,14 @@
 #   limitations under the License.
 
 """
-This is a fiblary package providing python API implementation to Home Center
+ fiblary.events
+ ~~~~~~~~~~~~~~
 
+ Home Center Events Manager Implementation
 """
 
+from fiblary3.client.v5 import base
 
-from fiblary3.common import utils
 
-
-def Client(version, *args, **kwargs):
-    """This is a client wrapper handling API versioning
-
-    :param version: A version string of the API (i.e. 'v3')
-    :returns: A Home Center Client class
-    """
-
-    module = utils.import_versioned_module('client', version, 'client')
-    client_class = getattr(module, 'Client')
-    return client_class(*args, **kwargs)
+class Controller(base.MinimalController):
+    RESOURCE = 'settings/info'

--- a/fiblary3/client/v5/login.py
+++ b/fiblary3/client/v5/login.py
@@ -1,3 +1,4 @@
+#  Copyright 2020 Daniel Pervan
 #  Copyright 2014 Klaudiusz Staniek
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,21 +14,14 @@
 #   limitations under the License.
 
 """
-This is a fiblary package providing python API implementation to Home Center
+ fiblary.login
+ ~~~~~~~~~~~~~~
 
+ Home Center Login Status Manager Implementation
 """
 
+from fiblary3.client.v5 import base
 
-from fiblary3.common import utils
 
-
-def Client(version, *args, **kwargs):
-    """This is a client wrapper handling API versioning
-
-    :param version: A version string of the API (i.e. 'v3')
-    :returns: A Home Center Client class
-    """
-
-    module = utils.import_versioned_module('client', version, 'client')
-    client_class = getattr(module, 'Client')
-    return client_class(*args, **kwargs)
+class Controller(base.MinimalController):
+    RESOURCE = 'loginStatus'

--- a/fiblary3/client/v5/models.py
+++ b/fiblary3/client/v5/models.py
@@ -1,0 +1,182 @@
+#  Copyright 2020 Daniel Pervan
+#  Copyright 2014 Klaudiusz Staniek
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""
+ fiblary.models
+ ~~~~~~~~~~~~~~~~~
+
+ Home Center Model Class Implementations
+
+"""
+
+import functools
+import jsonpatch
+import logging
+import six
+
+_logger = logging.getLogger(__name__)
+
+
+_type_ignore = ["HC_user", "VOIP_user", "weather", 'iOS_device', '']
+
+
+def factory(controller, item):
+    # try as item could be anything
+    try:
+        if item['type'] in _type_ignore:
+            return None
+    except Exception:
+        pass
+
+    model = None
+    if isinstance(item, dict):
+        if controller.RESOURCE == 'devices':
+            model = DeviceModel(controller, item)
+        elif controller.RESOURCE == 'scenes':
+            model = SceneModel(controller, item)
+        else:
+            model = GenericModel(controller, item)
+    elif isinstance(item, list):
+        model = RecursiveList(item)
+    else:
+        assert 0, "Unknown model"
+    return model
+
+
+class RecursiveList(list):
+
+    def __init__(self, value):
+        if value is None:
+            pass
+        elif isinstance(value, list):
+            for index, data in enumerate(value):
+                self.append(data)
+                self.__setitem__(index, data)
+        else:
+            raise TypeError('Expected list')
+
+        self.__dict__['__original__'] = value
+
+    def __getitem__(self, key):
+        return list.__getitem__(self, key)
+
+    def __setitem__(self, key, value):
+        if isinstance(value, str):
+            value = str(value)
+        if isinstance(value, list) and not isinstance(value, RecursiveList):
+            value = RecursiveList(value)
+
+        if isinstance(value, dict) and not isinstance(value, RecursiveDict):
+            value = RecursiveDict(value)
+
+        list.__setitem__(self, key, value)
+
+    __setattr__ = __setitem__
+    __getattr__ = __getitem__
+
+
+class RecursiveDict(dict):
+    def __init__(self, value=None):
+        if value is None:
+            pass
+        elif isinstance(value, dict):
+            for key in value:
+                self.__setitem__(key, value[key])
+        else:
+            raise TypeError('Expected dict')
+        self.__dict__['__original__'] = value
+
+    def changes(self):
+        original = self.__dict__['__original__']
+        return jsonpatch.make_patch(original, dict(self)).to_string()
+
+    def __setitem__(self, key, value):
+        if isinstance(value, str):
+            value = str(value)
+        if isinstance(value, dict) and not isinstance(value, RecursiveDict):
+            value = RecursiveDict(value)
+
+        if isinstance(value, list) and not isinstance(value, RecursiveList):
+            value = RecursiveList(value)
+
+        if not callable(value):
+            dict.__setitem__(self, key, value)
+        else:
+            # actions are callable so added only to the local dict
+            self.__dict__[key] = value
+
+    def __getitem__(self, key):
+        return dict.__getitem__(self, key)
+
+    def setdefault(self, key, default=None):
+        if key not in self:
+            self[key] = default
+        return self[key]
+
+    __setattr__ = __setitem__
+    __getattr__ = __getitem__
+
+
+class GenericModel(RecursiveDict):
+    def __init__(self, controller, item):
+        self.__dict__['controller'] = controller
+        super(GenericModel, self).__init__(item)
+
+
+class DeviceModel(GenericModel):
+    def __init__(self, controller, item):
+        super(DeviceModel, self).__init__(controller, item)
+
+        if 'actions' in self:
+            def action(action_name, argn, *args, **kwargs):
+                _logger.info("{0}({1})->{2}{3}".format(
+                    self.name, self.id, action_name, args)
+                )
+                if len(args) != argn:
+                    # hack due to http://bugzilla.fibaro.com/view.php?id=1125
+                    if action_name != 'setTargetLevel' and action_name != 'setColor':
+                        raise TypeError(
+                            "%s() takes exactly %d argument(s) (%d given)" % (
+                                action_name, argn, len(args))
+                        )
+                return self.controller.action(self.id, action_name, *args)
+
+            for action_name, argn in six.iteritems(self['actions']):
+                _logger.debug("{0}({1})<-{2}({3})".format(
+                    self.name,
+                    self.id,
+                    action_name,
+                    argn))
+
+                self.__dict__[str(action_name)] = functools.partial(
+                    action, action_name, argn)
+
+
+class SceneModel(GenericModel):
+    def __init__(self, controller, item):
+        super(SceneModel, self).__init__(controller, item)
+    """Home Center specific subclass for the Scene with actions"""
+
+    def start(self):
+        return self.controller.start(self.id)
+
+    def stop(self):
+        return self.controller.stop(self.id)
+
+    def enable(self):
+        return self.controller.enable(self.id)
+
+    def disable(self):
+        return self.controller.disable(self.id)

--- a/fiblary3/client/v5/rooms.py
+++ b/fiblary3/client/v5/rooms.py
@@ -1,3 +1,4 @@
+#  Copyright 2020 Daniel Pervan
 #  Copyright 2014 Klaudiusz Staniek
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,21 +14,15 @@
 #   limitations under the License.
 
 """
-This is a fiblary package providing python API implementation to Home Center
+ fiblary.rooms
+ ~~~~~~~~~~~~~~
 
+ Home Center Room Manager Implementation
 """
 
+from fiblary3.client.v5 import base
 
-from fiblary3.common import utils
 
-
-def Client(version, *args, **kwargs):
-    """This is a client wrapper handling API versioning
-
-    :param version: A version string of the API (i.e. 'v3')
-    :returns: A Home Center Client class
-    """
-
-    module = utils.import_versioned_module('client', version, 'client')
-    client_class = getattr(module, 'Client')
-    return client_class(*args, **kwargs)
+class Controller(base.CommonController):
+    RESOURCE = 'rooms'
+    API_PARAMS = ('id', 'sectionID')

--- a/fiblary3/client/v5/scenes.py
+++ b/fiblary3/client/v5/scenes.py
@@ -1,0 +1,94 @@
+#  Copyright 2014 Klaudiusz Staniek
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""
+ fiblary.scenes
+ ~~~~~~~~~~~~~~
+
+ Home Center Scene Manager Implementation
+"""
+
+import logging
+
+from fiblary3.client.v5 import base
+from fiblary3.common import exceptions
+
+
+_logger = logging.getLogger(__name__)
+
+
+class Controller(base.CommonController):
+    RESOURCE = 'scenes'
+
+    def _scene_control(self, scene_id, action=None, data=None, method=None):
+        cmd = '{}/{}'.format(self.RESOURCE, scene_id)
+        if action is not None:
+            cmd = '{}/{}'.format(cmd, action)
+        if data is None:
+            data = "{}"
+        if method == "PUT":
+            resp = self.http_client.put(cmd, data=data)
+        else:
+            resp = self.http_client.post(cmd, data=data)
+
+        if resp.status_code != 202:
+            exceptions.from_response(resp)
+        return self.get(scene_id)
+
+    def _scene_post(self, scene_id, action=None, data=None):
+        return self._scene_control(scene_id, action, data)
+
+    def _scene_put(self, scene_id, action=None, data=None):
+        return self._scene_control(scene_id, action, data, "PUT")
+
+    def start(self, scene_id):
+        scene = self._scene_post(scene_id, "execute")
+        _logger.info("Scene {}({}) started".format(scene.name, scene.id))
+        return scene
+
+    def stop(self, scene_id, pin=None):
+        data = {}
+        if pin is not None:
+            data = '{"pin": "{0}"}'.format(pin)
+        scene = self._scene_post(scene_id, "kill", data)
+        _logger.info("Scene {}({}) stopped".format(scene.name, scene.id))
+        return scene
+
+    def enable(self, scene_id):
+        data = '{ "enabled": true }'
+        scene = self._scene_put(scene_id, data=data)
+        _logger.info("Scene {}({}) enabled".format(scene.name, scene.id))
+        return scene
+
+    def disable(self, scene_id):
+        data = '{ "enabled": false }'
+        scene = self._scene_put(scene_id, data=data)
+        _logger.info("Scene {}({}) disabled".format(scene.name, scene.id))
+        return scene
+
+    def update(self, data):
+        # scene is Null due to
+        # http://bugzilla.fibaro.com/view.php?id=1176
+        # must be retrieved again
+        scene = super(Controller, self).update(data)
+        try:
+            scene_id = data['id']
+            if scene_id:
+                _logger.warning(
+                    "Refer to: http://bugzilla.fibaro.com/view.php?id=1176")
+                scene = self.get(scene_id)
+        except Exception:
+            pass
+
+        return scene

--- a/fiblary3/client/v5/sections.py
+++ b/fiblary3/client/v5/sections.py
@@ -1,3 +1,4 @@
+#  Copyright 2020 Daniel Pervan
 #  Copyright 2014 Klaudiusz Staniek
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,21 +14,15 @@
 #   limitations under the License.
 
 """
-This is a fiblary package providing python API implementation to Home Center
+ fiblary.sections
+ ~~~~~~~~~~~~~~
 
+ Home Center Section Manager Implementation
 """
 
+from fiblary3.client.v5 import base
 
-from fiblary3.common import utils
 
-
-def Client(version, *args, **kwargs):
-    """This is a client wrapper handling API versioning
-
-    :param version: A version string of the API (i.e. 'v3')
-    :returns: A Home Center Client class
-    """
-
-    module = utils.import_versioned_module('client', version, 'client')
-    client_class = getattr(module, 'Client')
-    return client_class(*args, **kwargs)
+class Controller(base.CommonController):
+    RESOURCE = 'sections'
+    API_PARAMS = ('id')

--- a/fiblary3/client/v5/users.py
+++ b/fiblary3/client/v5/users.py
@@ -1,3 +1,4 @@
+#  Copyright 2020 Daniel Pervan
 #  Copyright 2014 Klaudiusz Staniek
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,21 +14,15 @@
 #   limitations under the License.
 
 """
-This is a fiblary package providing python API implementation to Home Center
+ fiblary.users
+ ~~~~~~~~~~~~~~
 
+ Home Center User Manager Implementation
 """
 
 
-from fiblary3.common import utils
+from fiblary3.client.v5 import base
 
 
-def Client(version, *args, **kwargs):
-    """This is a client wrapper handling API versioning
-
-    :param version: A version string of the API (i.e. 'v3')
-    :returns: A Home Center Client class
-    """
-
-    module = utils.import_versioned_module('client', version, 'client')
-    client_class = getattr(module, 'Client')
-    return client_class(*args, **kwargs)
+class Controller(base.CommonController):
+    RESOURCE = 'users'

--- a/fiblary3/client/v5/variables.py
+++ b/fiblary3/client/v5/variables.py
@@ -1,0 +1,59 @@
+#  Copyright 2020 Daniel Pervan
+#  Copyright 2014 Klaudiusz Staniek
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""
+ fiblary.variables
+ ~~~~~~~~~~~~~~
+
+ Home Center Variable Manager Implementation
+"""
+
+import logging
+
+from fiblary3.client.v5 import base
+from fiblary3.common import exceptions
+
+# TODO(kstaniek): Handle predefined variables
+
+_logger = logging.getLogger(__name__)
+
+
+class Controller(base.CommonController):
+    RESOURCE = 'globalVariables'
+
+    def get(self, item_id):
+        url = '{0}/{1}'.format(self.RESOURCE, item_id)
+        item = self.http_client.get(url).json()
+        return self.model(item)
+
+    def delete(self, item_id):
+        url = '{0}/{1}'.format(self.RESOURCE, item_id)
+        self.http_client.delete(url)
+        return
+
+    def set(self, name, value):
+        data = {
+            'value': value
+        }
+        try:
+            url = "%s/%s" % (self.RESOURCE, name)
+            item = self.http_client.put(url, json=data)
+
+            _logger.info('Variable set: {0}="{1}"'.format(name, value))
+        except exceptions.HTTPNotFound:
+            _logger.info('Variable created: {0}="{1}"'.format(name, value))
+            item = self.create(data)
+
+        return self.model(item.json())

--- a/fiblary3/client/v5/weather.py
+++ b/fiblary3/client/v5/weather.py
@@ -1,3 +1,4 @@
+#  Copyright 2020 Daniel Pervan
 #  Copyright 2014 Klaudiusz Staniek
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,21 +14,14 @@
 #   limitations under the License.
 
 """
-This is a fiblary package providing python API implementation to Home Center
+ fiblary.weather
+ ~~~~~~~~~~~~~~
 
+ Home Center Weather Manager Implementation
 """
 
+from fiblary3.client.v5 import base
 
-from fiblary3.common import utils
 
-
-def Client(version, *args, **kwargs):
-    """This is a client wrapper handling API versioning
-
-    :param version: A version string of the API (i.e. 'v3')
-    :returns: A Home Center Client class
-    """
-
-    module = utils.import_versioned_module('client', version, 'client')
-    client_class = getattr(module, 'Client')
-    return client_class(*args, **kwargs)
+class Controller(base.MinimalController):
+    RESOURCE = 'weather'

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ packages = [
     'fiblary3.client',
     'fiblary3.client.v3',
     'fiblary3.client.v4',
+    'fiblary3.client.v5',
     'fiblary3.common',
     'fiblary3.external',
 ]
@@ -45,7 +46,7 @@ with open('README.rst') as f:
 setup(
     name='fiblary3',
     version=fiblary3.__version__,
-    description='Home Center 2 API Python Library',
+    description='Home Center API Python Library',
     long_description=readme,
     author='Peter Balogh',
     author_email='peter.balogh2@gmail.com',


### PR DESCRIPTION
I've added some preliminary support for Home Center 3. It's relatively quick and dirty, but it should work. 

The way the resource URL is formatted should probably be rewritten at some point since version 5 mostly uses RESTful path parameters rather than query parameters like in version 4. 