### PR TITLE
Improve tests

### DIFF
--- a/fiblary3/common/event.py
+++ b/fiblary3/common/event.py
@@ -38,7 +38,7 @@ class EventQueue(threading.Thread):
     def __init__(self, name=None):
         super(EventQueue, self).__init__(name=name or self.__class__.__name__)
         self.queue = queue.Queue()
-        self._stop = threading.Event()
+        self._stopper = threading.Event()
 
         self.n = 0
         self.serving = None
@@ -63,7 +63,7 @@ class EventQueue(threading.Thread):
 
     def stop(self):
         _logger.info("Stopping the event queue for {}".format(self.name))
-        self._stop.set()
+        self._stopper.set()
         self.put("EXIT")
 
     def run(self):
@@ -89,7 +89,7 @@ class EventQueue(threading.Thread):
             self.n += 1
 
     def stopped(self):
-        return self._stop.isSet()
+        return self._stopper.isSet()
 
 
 def queue_event(f):

--- a/fiblary3/common/restapi.py
+++ b/fiblary3/common/restapi.py
@@ -89,7 +89,7 @@ class RESTApi(object):
             session = requests.Session()
         self.session = session
         self.session.verify = verify
-        self.session.user_agent = user_agent
+        self.session.headers['User-Agent'] = user_agent
         self.session.stream = False
 
         if logger:

--- a/fiblary3/tests/unit/test_timestamp.py
+++ b/fiblary3/tests/unit/test_timestamp.py
@@ -22,4 +22,4 @@ class TestUtils(testtools.TestCase):
     def test_timestamp_to_iso(self):
         self.assertEqual(
             timestamp.timestamp_to_iso(123123123),
-            "1973-11-26 01:52:03")
+            "1973-11-26 00:52:03")

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,5 +3,5 @@ testrepository>=0.0.17
 coverage>=3.6
 discover
 fixtures>=0.3.14
-mock>=1.0
 testtools>=0.9.32
+requests-mock>=1.8.0


### PR DESCRIPTION
I use this library as part of Home Assistant and am in the process of packaging it in Nixpkgs (https://github.com/NixOS/nixpkgs/pull/114049).  As part of that process, I noticed that there were a lot of failed tests, and since I depend on this library for my home automation I thought it would be worth spending some time to fix them.

Please let me know what you think of the changes here.  The main one is to use `requests-mock`, which is cleaner but also avoids a bunch of  exceptions that appear in more recent versions of `requests` (it now expects the content of requests to always be bytes).

I also had another request, which I would have raised as an issue but Issues don't seem to be enabled on this repo: could tags for the recent releases be pushed?  I don't see any since 0.1.3, but I'd much rather use a tag for 0.1.8 rather than a specific commit.  Could you also enable Issues on this repo for future requests?

Once the tests are running again it would be worth considering some kind of CI (e.g. via Github actions).

Thanks very much for the library, it's very useful!